### PR TITLE
Revert Endless Documentation Team->GNOME Documentation Team

### DIFF
--- a/gnome-help/C/app-banshee.page.stub
+++ b/gnome-help/C/app-banshee.page.stub
@@ -7,7 +7,7 @@
     <revision pkgversion="3.0" date="2011-03-22" status="stub"/>
 
     <credit type="author">
-      <name>Endless Documentation Team</name>
+      <name>GNOME Documentation Team</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/app-cheese.page.stub
+++ b/gnome-help/C/app-cheese.page.stub
@@ -7,7 +7,7 @@
     <revision pkgversion="3.0" date="2011-03-22" status="stub"/>
 
     <credit type="author">
-      <name>Endless Documentation Team</name>
+      <name>GNOME Documentation Team</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/app-evolution-setup.page.stub
+++ b/gnome-help/C/app-evolution-setup.page.stub
@@ -7,7 +7,7 @@
     <revision pkgversion="3.0" date="2011-04-14" status="stub"/>
 
     <credit type="author">
-      <name>Endless Documentation Team</name>
+      <name>GNOME Documentation Team</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/app-fspot.page.stub
+++ b/gnome-help/C/app-fspot.page.stub
@@ -7,7 +7,7 @@
     <revision pkgversion="3.0" date="2011-03-22" status="stub"/>
 
     <credit type="author">
-      <name>Endless Documentation Team</name>
+      <name>GNOME Documentation Team</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/app-pitivi.page.stub
+++ b/gnome-help/C/app-pitivi.page.stub
@@ -7,7 +7,7 @@
     <revision pkgversion="3.0" date="2011-03-22" status="stub"/>
 
     <credit type="author">
-      <name>Endless Documentation Team</name>
+      <name>GNOME Documentation Team</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/app-rhythmbox.page.stub
+++ b/gnome-help/C/app-rhythmbox.page.stub
@@ -7,7 +7,7 @@
     <revision pkgversion="3.0" date="2011-03-22" status="stub"/>
 
     <credit type="author">
-      <name>Endless Documentation Team</name>
+      <name>GNOME Documentation Team</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/app-shotwell.page.stub
+++ b/gnome-help/C/app-shotwell.page.stub
@@ -7,7 +7,7 @@
     <revision pkgversion="3.0" date="2011-03-22" status="stub"/>
 
     <credit type="author">
-      <name>Endless Documentation Team</name>
+      <name>GNOME Documentation Team</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/app-totem.page.stub
+++ b/gnome-help/C/app-totem.page.stub
@@ -7,7 +7,7 @@
     <revision pkgversion="3.0" date="2011-03-22" status="stub"/>
 
     <credit type="author">
-      <name>Endless Documentation Team</name>
+      <name>GNOME Documentation Team</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/backup-check.page
+++ b/gnome-help/C/backup-check.page
@@ -9,7 +9,7 @@
     <revision pkgversion="3.4.0" date="2012-02-19" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <include href="legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>

--- a/gnome-help/C/backup-frequency.page
+++ b/gnome-help/C/backup-frequency.page
@@ -14,7 +14,7 @@
       <email>tiffany.antopolski@gmail.com</email>
     </credit>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <include href="legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>

--- a/gnome-help/C/backup-how.page
+++ b/gnome-help/C/backup-how.page
@@ -13,7 +13,7 @@
       <email>tiffany.antopolski@gmail.com</email>
     </credit>
     <credit>
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/backup-restore.page
+++ b/gnome-help/C/backup-restore.page
@@ -13,7 +13,7 @@
       <email>tiffany.antopolski@gmail.com</email>
     </credit>
     <credit>
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/backup-what.page
+++ b/gnome-help/C/backup-what.page
@@ -9,7 +9,7 @@
     <revision pkgversion="3.4.0" date="2012-02-19" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/backup-where.page
+++ b/gnome-help/C/backup-where.page
@@ -11,7 +11,7 @@
     <revision pkgversion="3.4.0" date="2012-02-19" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/clock-set.page
+++ b/gnome-help/C/clock-set.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-11-01" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/clock-timezone.page
+++ b/gnome-help/C/clock-timezone.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-11-01" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/display-dimscreen.page.stub
+++ b/gnome-help/C/display-dimscreen.page.stub
@@ -14,7 +14,7 @@
     <revision pkgversion="3.8" version="0.4" date="2013-03-28" status="candidate"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/files-recover.page
+++ b/gnome-help/C/files-recover.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.6.0" version="0.2" date="2012-09-28" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/files-rename.page
+++ b/gnome-help/C/files-rename.page
@@ -9,7 +9,7 @@
     <revision pkgversion="3.5.92" version="0.2" date="2012-09-19" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/files-search.page
+++ b/gnome-help/C/files-search.page
@@ -8,7 +8,7 @@
     <revision pkgversion="3.6.0" version="0.2" date="2012-09-25" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/hardware-phone-connecting.page.stub
+++ b/gnome-help/C/hardware-phone-connecting.page.stub
@@ -9,7 +9,7 @@
 
     <revision pkgversion="3.0" version="0.1" date="2011-03-25" status="stub"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/keyboard-key-super.page
+++ b/gnome-help/C/keyboard-key-super.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.9.92" date="2013-09-23" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/look-background.page
+++ b/gnome-help/C/look-background.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-11-07" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/net-antivirus.page
+++ b/gnome-help/C/net-antivirus.page
@@ -10,7 +10,7 @@
     <desc>Learn about anti-virus software and your Endless computer.</desc>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/net-mobile.page.stub
+++ b/gnome-help/C/net-mobile.page.stub
@@ -7,7 +7,7 @@
     <revision pkgversion="3.0" date="2011-03-20" status="stub"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/net-wired-connect.page
+++ b/gnome-help/C/net-wired-connect.page
@@ -7,7 +7,7 @@
     <revision pkgversion="3.4.0" date="2012-02-20" status="final"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/net-wireless-airplane.page
+++ b/gnome-help/C/net-wireless-airplane.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" version="0.2" date="2013-11-10" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/net-wireless-connect.page
+++ b/gnome-help/C/net-wireless-connect.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-12-05" status="final"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/net-wireless-find.page
+++ b/gnome-help/C/net-wireless-find.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" version="0.2" date="2013-11-10" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/net-wireless-hidden.page
+++ b/gnome-help/C/net-wireless-hidden.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-12-05" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/net-wireless-wepwpa.page
+++ b/gnome-help/C/net-wireless-wepwpa.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" version="0.2" date="2013-11-10" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/photos-print-fullpage.page.stub
+++ b/gnome-help/C/photos-print-fullpage.page.stub
@@ -10,7 +10,7 @@
 
     <revision pkgversion="3.0" version="0.1" date="2011-03-25" status="stub"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/power-batterycapacity.page.old
+++ b/gnome-help/C/power-batterycapacity.page.old
@@ -10,7 +10,7 @@
     <desc>Batteries get less efficient at storing charge as they get older, so you might want to check how efficient your battery is.</desc>
     <revision pkgversion="3.0" version="0.1" date="2011-03-19" status="outdated"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     

--- a/gnome-help/C/power-turnoffbutton.page.old
+++ b/gnome-help/C/power-turnoffbutton.page.old
@@ -6,7 +6,7 @@
     <link type="guide" xref="power"/>
     <desc>Look in <guiseq><gui>Settings</gui><gui>Power</gui></guiseq> for the option to change this.</desc>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     

--- a/gnome-help/C/printing-setup-networked.page.stub
+++ b/gnome-help/C/printing-setup-networked.page.stub
@@ -38,7 +38,7 @@
   <p>Your home or office network may include a printer. Many modern, inexpensive printers can be directly attached to your network. If you're in an office environment, your system administration staff should be able to provide details about the available network printers.</p>
 
   <comment>
-    <cite date="2011-03-20" href="mailto:gnome-docs-list@gnome.org">Endless Documentation Project</cite>
+    <cite date="2011-03-20" href="mailto:gnome-docs-list@gnome.org">GNOME Documentation Project</cite>
     <p>Let's assume that the printer is shared out correctly in a way that makes it discoverable (via mDNS/avahi) and that it's providing CUPS/IPP service over port 631. These capabilities are typical in most modern printers that have cross-platform support.</p>
     <p>Perhaps installing a printer in that way on Endless should be covered elsewhere, but the capability doesn't currently exist in the Endless Printers tool, meaning it would need to be covered by distros.</p>
   </comment>

--- a/gnome-help/C/session-language.page
+++ b/gnome-help/C/session-language.page
@@ -12,7 +12,7 @@
     <revision pkgversion="3.8.0" version="0.3" date="2013-03-13" status="candidate"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/session-loginsound.page.old
+++ b/gnome-help/C/session-loginsound.page.old
@@ -11,7 +11,7 @@
     <!-- Can you do this any more? Is there even a login sound? -->
     
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     
@@ -87,7 +87,7 @@
  </note>
 
   <comment>
-   <cite date="2010-10-31" href="mailto:gnome-doc-list@gnome.org">Endless Documentation Project</cite>
+   <cite date="2010-10-31" href="mailto:gnome-doc-list@gnome.org">GNOME Documentation Project</cite>
    <p>Instructions on turning off the sound that is made when the user logs in. Mention how to change it too, and how to make it quieter.</p>
   </comment>
 	

--- a/gnome-help/C/session-netlogin.page.stub
+++ b/gnome-help/C/session-netlogin.page.stub
@@ -8,7 +8,7 @@
     <desc>XXXXX</desc>
     <revision pkgversion="3.0" version="0.1" date="2011-03-19" status="stub"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 
@@ -18,7 +18,7 @@
 <title>Log-in over a network</title>
 
   <comment>
-   <cite date="2010-10-31" href="mailto:gnome-doc-list@gnome.org">Endless Documentation Project</cite>
+   <cite date="2010-10-31" href="mailto:gnome-doc-list@gnome.org">GNOME Documentation Project</cite>
    <p>Difficult set of topics! Explain how to set-up different types of network logins, and how the user can log-in over a network via GDM etc. Mention some common problems and how to resolve them.</p>
   </comment>
 	

--- a/gnome-help/C/session-smartcard.page.stub
+++ b/gnome-help/C/session-smartcard.page.stub
@@ -7,7 +7,7 @@
     <desc>You can use a supported smartcard to log in to your system.</desc>
     <revision pkgversion="3.0" version="0.2" date="2011-03-19" status="stub"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 
@@ -17,7 +17,7 @@
   <title>Log in with a smart card</title>
 
   <comment>
-    <cite date="2011-03-19" href="mailto:gnome-doc-list@gnome.org">Endless Documentation Project</cite>
+    <cite date="2011-03-19" href="mailto:gnome-doc-list@gnome.org">GNOME Documentation Project</cite>
     <p>Explain how to set up and use a typical smart card for logging in. If methods differ by model, attempt to group into major classes and explain.</p>
   </comment>
 

--- a/gnome-help/C/shell-apps-forcequit.page.stub
+++ b/gnome-help/C/shell-apps-forcequit.page.stub
@@ -11,7 +11,7 @@
     <desc>Press <keyseq><key>Alt</key><key>F2</key></keyseq>. Type <input>xkill</input>.</desc>
     <revision pkgversion="3.0" version="0.1" date="2011-03-19" status="review"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/shell-apps-open.page
+++ b/gnome-help/C/shell-apps-open.page
@@ -8,7 +8,7 @@
 
     <revision pkgversion="3.6.0" version="0.2" date="2012-10-14" status="review"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/shell-apps-search.page.old
+++ b/gnome-help/C/shell-apps-search.page.old
@@ -8,7 +8,7 @@
     <revision pkgversion="3.0" version="0.1" date="2011-02-26" status="outdated"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/shell-net-remote.page.stub
+++ b/gnome-help/C/shell-net-remote.page.stub
@@ -9,7 +9,7 @@
 
     <revision pkgversion="3.0" version="0.1" date="2011-03-25" status="stub"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/shell-overview.page
+++ b/gnome-help/C/shell-overview.page
@@ -8,7 +8,7 @@
     <revision pkgversion="3.4.0" date="2012-02-19" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/shell-prefs.page.old
+++ b/gnome-help/C/shell-prefs.page.old
@@ -10,7 +10,7 @@
     <desc>Alter desktop settings.</desc>
     <revision pkgversion="3.0" version="0.1" date="2011-03-19" status="review"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     

--- a/gnome-help/C/shell-windows-switching.page
+++ b/gnome-help/C/shell-windows-switching.page
@@ -9,7 +9,7 @@
     <revision pkgversion="3.4.0" date="2012-02-19" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/templates/games/README
+++ b/gnome-help/C/templates/games/README
@@ -6,6 +6,6 @@ GENERIC.page.stub can be used as a generic topic page. Just make a copy, rename 
 
 Rename the pages from ".page.stub" to ".page" when you have edited them.
 
-Contact the Endless Documentation Team (gnome-doc-list@gnome.org) for help with this template.
+Contact the GNOME Documentation Team (gnome-doc-list@gnome.org) for help with this template.
 
 (Original author: Phil Bull <philbull@gmail.com>, 24-Jun-2010. The license for this template is Public Domain. You may relicense it as you wish.)

--- a/gnome-help/C/templates/games/controls-changing.page.stub
+++ b/gnome-help/C/templates/games/controls-changing.page.stub
@@ -18,7 +18,7 @@
 
 <comment>
  <title>Purpose of document</title>
- <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">Endless Documentation Project</cite>
+ <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">GNOME Documentation Project</cite>
  <p>Use this topic to explain how the game controls can be changed.</p>
  <p>This topic is linked to from <cmd>controls</cmd>.</p>
 </comment>

--- a/gnome-help/C/templates/games/controls.page.stub
+++ b/gnome-help/C/templates/games/controls.page.stub
@@ -18,7 +18,7 @@
 
 <comment>
  <title>Purpose of document</title>
- <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">Endless Documentation Project</cite>
+ <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">GNOME Documentation Project</cite>
  <p>Use this topic to provide a full list of controls of the game.</p>
  <p>Players can use this topic for reference.</p>
  <p>Try to group controls in a logical manner. Use sections to group similar controls.</p>

--- a/gnome-help/C/templates/games/gameplay.page.stub
+++ b/gnome-help/C/templates/games/gameplay.page.stub
@@ -18,7 +18,7 @@
 
 <comment>
  <title>Purpose of document</title>
- <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">Endless Documentation Project</cite>
+ <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">GNOME Documentation Project</cite>
  <p>Use this topic to explain the fundamentals of how to play the game.</p>
  <p>It should be a quick-start guide, which aims to get the user playing the game at a basic level as quickly as possible.</p>
  <p>Only mention the more basic controls and rules. Link to other topics to explain things in more detail.</p>

--- a/gnome-help/C/templates/games/multiplayer.page.stub
+++ b/gnome-help/C/templates/games/multiplayer.page.stub
@@ -18,7 +18,7 @@
 
 <comment>
  <title>Purpose of document</title>
- <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">Endless Documentation Project</cite>
+ <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">GNOME Documentation Project</cite>
  <p>Use this guide page to collect topics which cover setting-up, joining, and playing multiplayer games.</p>
  <p>Some games don't have multiplayer modes, and so won't need this page.</p>
  <p>For consistency, consider starting the names of all multiplayer topics with "multiplayer-", e.g. "multiplayer-starting.page".</p>

--- a/gnome-help/C/templates/games/strategy.page.stub
+++ b/gnome-help/C/templates/games/strategy.page.stub
@@ -18,7 +18,7 @@
 
 <comment>
  <title>Purpose of document</title>
- <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">Endless Documentation Project</cite>
+ <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">GNOME Documentation Project</cite>
  <p>Use this topic page to describe strategies that the user might be able to use to win the game. Use a new section for each major strategy.</p>
  <p>The idea behind this topic is to give the user some hints on how they could improve their success rate in the game. Lots of games have useful (but not obvious) strategies; for example, Chess has the "castling" manoeuvre.</p>
  <p>If possible, don't be too specific about how effective each strategy is. Telling the user which is the best strategy may make it too easy for them to win, and could spoil the game.</p>

--- a/gnome-help/C/templates/games/tips.page.stub
+++ b/gnome-help/C/templates/games/tips.page.stub
@@ -18,7 +18,7 @@
 
 <comment>
  <title>Purpose of document</title>
- <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">Endless Documentation Project</cite>
+ <cite date="2010-06-24" href="mailto:gnome-doc-list@gnome.org">GNOME Documentation Project</cite>
  <p>Use this guide page to collect topics which provide useful tips on how to play the game.</p>
  <p>Tips and tricks are information that help the user play the game in a more satisfying or efficient way. These might include:</p>
  <list>

--- a/gnome-help/C/user-add.page
+++ b/gnome-help/C/user-add.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-11-01" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/user-addguest.page.old
+++ b/gnome-help/C/user-addguest.page.old
@@ -9,7 +9,7 @@
     <revision pkgversion="3.8.0" version="0.3" date="2013-03-09" status="candidate"/>
 
     <credit type="maintainer">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/user-admin-change.page
+++ b/gnome-help/C/user-admin-change.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-11-01" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/user-admin-explain.page
+++ b/gnome-help/C/user-admin-explain.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-11-03" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/user-admin-problems.page
+++ b/gnome-help/C/user-admin-problems.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-11-03" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/user-changepassword.page
+++ b/gnome-help/C/user-changepassword.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-11-01" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="editor">

--- a/gnome-help/C/user-changepicture.page
+++ b/gnome-help/C/user-changepicture.page
@@ -10,7 +10,7 @@
     <revision pkgversion="3.10" date="2013-11-01" status="review"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/user-delete.page
+++ b/gnome-help/C/user-delete.page
@@ -14,7 +14,7 @@
       <email its:translate="no">tiffany@antopolski.com</email>
     </credit>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email its:translate="no">gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/user-forgottenpassword.page.old
+++ b/gnome-help/C/user-forgottenpassword.page.old
@@ -8,7 +8,7 @@
     <revision pkgversion="3.0" date="2011-02-22" status="final"/>
     <revision pkgversion="3.0" version="3.0.1" date="2011-04-15" status="incomplete"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/user-goodpassword.page
+++ b/gnome-help/C/user-goodpassword.page
@@ -9,7 +9,7 @@
     <revision pkgversion="3.8.0" date="2013-03-09" status="candidate"/>
 
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
     <credit type="author">

--- a/gnome-help/C/video-dvd-noplay.page.stub
+++ b/gnome-help/C/video-dvd-noplay.page.stub
@@ -9,7 +9,7 @@
 
     <revision pkgversion="3.0" version="0.1" date="2011-03-25" status="stub"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/video-nosound.page.stub
+++ b/gnome-help/C/video-nosound.page.stub
@@ -9,7 +9,7 @@
 
     <revision pkgversion="3.0" version="0.1" date="2011-03-25" status="stub"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 

--- a/gnome-help/C/video-wontplay.page.stub
+++ b/gnome-help/C/video-wontplay.page.stub
@@ -9,7 +9,7 @@
 
     <revision pkgversion="3.0" version="0.1" date="2011-03-25" status="stub"/>
     <credit type="author">
-      <name>Endless Documentation Project</name>
+      <name>GNOME Documentation Project</name>
       <email>gnome-doc-list@gnome.org</email>
     </credit>
 


### PR DESCRIPTION
The Endless Documentation Team is not yet a thing, we should give
credit where credit is due.
[endlessm/eos-shell#3977]
