### PR TITLE
Use consistent markup for Enter key

### DIFF
--- a/gnome-help/C/shell-organize-apps.page
+++ b/gnome-help/C/shell-organize-apps.page
@@ -34,7 +34,7 @@
     </item>
     <item>
       <p>Type a name for your new folder ("School", for example) and hit
-      <input>Enter.</input></p>
+      <key>Enter</key>.</p>
     </item>
     <item>
       <p>You have added a new folder to the desktop. Great! Now click on the


### PR DESCRIPTION
The `<key>` markup is the correct annotation
[endlessm/eos-shell#4346]
