### PR TITLE
Remove reference to writer printing icon

### DIFF
--- a/gnome-help/C/printing-from-applications.page
+++ b/gnome-help/C/printing-from-applications.page
@@ -33,7 +33,7 @@
     <item>
       <p>Click on the <gui>Print</gui> option near the bottom of the list in that
       menu. You can also press <keyseq><key>Ctrl</key><key>P</key></keyseq> from
-      the document, or click on the [writer_printer.png] icon instead.</p>
+      the document.</p>
     </item>
     <item>
       <p>Select the printer that you want to print to and add any other


### PR DESCRIPTION
We don't have that asset, so well cut the text that references it
for now.

[endlessm/eos-shell#4237]
