### PR TITLE
Fix a couple missed references to App Store

### DIFF
--- a/gnome-help/C/screen-shot-record.page
+++ b/gnome-help/C/screen-shot-record.page
@@ -39,8 +39,8 @@
  <title>Take a screenshot</title>
 <steps>
 <item>
-  <p>Install the <gui>Screenshot</gui> application from the <gui>App
-  Store</gui>, under the <gui>Utilities</gui> category, and open it.</p>
+  <p>Install the <gui>Screenshot</gui> application from the <app>App
+  Center</app>, under the <gui>Utilities</gui> category, and open it.</p>
   <media its:translate="no" type="image" mime="image/png" src="figures/eos-desktop-app-store.png"/>
   <media its:translate="no" type="image" mime="image/png" src="figures/eos-app-store-tools.png"/>
 </item>

--- a/gnome-help/C/shell-install-ext-apps.page
+++ b/gnome-help/C/shell-install-ext-apps.page
@@ -20,8 +20,8 @@
 
   <title>Install apps that don't come on Endless</title>
 
-  <p>Currently, it is not possible to install software or apps outside of the <gui>App
-  Store</gui>. Luckily, Endless comes with a lot of great, and free, apps for
+  <p>Currently, it is not possible to install software or apps outside of the <app>App
+  Center</app>. Luckily, Endless comes with a lot of great, and free, apps for
   you to explore!</p>
 
   <p>If you have a specific app that you would like to see on Endless in the


### PR DESCRIPTION
We should call it the App Center now
[endlessm/eos-sdk#3412]