### PR TITLE
Add "Give Us Feedback" to the index page

### DIFF
--- a/gnome-help/C/index.page
+++ b/gnome-help/C/index.page
@@ -16,8 +16,8 @@
 
 <links type="topic" style="2column nodesc" role="index"/>
 
-<section id="endless-tutorial">
-  <title><link href = "endlessm-app://com.endlessm.Tutorial">Tutorial</link></title>
+<section id="endless-feedback">
+  <title><link href = "endlessm-app://eos-link-feedback.desktop">Give Us Feedback</link></title>
 </section>
 
 </page>


### PR DESCRIPTION
Replacing the previous launcher of the Endless tutorial
app, this commit adds a link to "Give Us Feedback", which
opens a Chromium window with that page.

https://phabricator.endlessm.com/T16842