### PR TITLE
debian/control: Make gnome-user-guide provide gnome-user-docs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Vcs-Svn: svn://anonscm.debian.org/svn/pkg-gnome/desktop/unstable/gnome-user-docs
 Vcs-Browser: http://anonscm.debian.org/viewvc/pkg-gnome/desktop/unstable/gnome-user-docs
 
 Package: gnome-user-guide
+Provides: gnome-user-docs
 Architecture: all
 Depends: ${misc:Depends},
          yelp (>= 3)


### PR DESCRIPTION
This makes it consistent with the source package's name, and it's
also what current packages from Debian would expect.

https://phabricator.endlessm.com/T21321