### PR TITLE
Restore references to fast user switching

### DIFF
--- a/gnome-help/C/shell-exit.page
+++ b/gnome-help/C/shell-exit.page
@@ -74,12 +74,17 @@
   <p>To <gui>Log Out</gui>, click the user menu on the right side of the taskbar,
   expand <gui>Power Off / Log Out</gui>, and select <gui>Log Out</gui>.</p>
 
-  <note if:test="!platform:gnome-classic">
+  <note if:test="!platform:gnome-classic !platform:endless">
     <p>The <gui>Log Out</gui> and <gui>Switch User</gui> entries only appear in
     the menu if you have more than one user account on your system.</p>
   </note>
 
   <note if:test="platform:gnome-classic">
+    <p>The <gui>Switch User</gui> entry only appears in the menu if you have
+    more than one user account on your system.</p>
+  </note>
+
+  <note if:test="platform:endless">
     <p>The <gui>Switch User</gui> entry only appears in the menu if you have
     more than one user account on your system.</p>
   </note>

--- a/gnome-help/C/shell-exit.page
+++ b/gnome-help/C/shell-exit.page
@@ -71,8 +71,10 @@
   your applications will continue running, and everything will be where you
   left it when you log back in.</p>
 
-  <p>To <gui>Log Out</gui>, click the user menu on the right side of the taskbar,
-  expand <gui>Power Off / Log Out</gui>, and select <gui>Log Out</gui>.</p>
+  <p>To <gui>Log Out</gui> or <gui>Switch User</gui>, click the
+  <link xref="shell-introduction#usermenu">user menu</link> on the right
+  side of the taskbar, expand <gui>Power Off / Log Out</gui>, and then
+  choose the correct option.</p>
 
   <note if:test="!platform:gnome-classic !platform:endless">
     <p>The <gui>Log Out</gui> and <gui>Switch User</gui> entries only appear in

--- a/gnome-help/C/shell-exit.page
+++ b/gnome-help/C/shell-exit.page
@@ -108,6 +108,10 @@
   <p>To lock your screen, click the user menu on the right side of the
   taskbar and select <gui>Lock</gui> from the menu.</p>
 
+  <p>When your screen is locked, other users can log in to their own accounts
+  by clicking <gui>Log in as another user</gui> at the bottom right of the login
+  screen. You can switch back to your desktop when they are finished.</p>
+
 </section>
 
 <section id="suspend">

--- a/gnome-help/C/shell-exit.page
+++ b/gnome-help/C/shell-exit.page
@@ -47,12 +47,12 @@
 
     <include href="legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>
 
-    <desc>Learn how to leave your user account, by logging out, powering
-    off, and so on.</desc>
+    <desc>Learn how to leave your user account, by logging out, switching
+    users, and so on.</desc>
     <!-- Should this be a guide which links to other topics? -->
   </info>
 
-  <title>Log out, suspend or power off</title>
+  <title>Log out, power off or switch users</title>
 
 <comment>
   <cite date="2012-02-19">shaunm</cite>
@@ -64,14 +64,17 @@
   it (to save power), or leave it powered on and log out.</p>
 
 <section id="logout">
-  <title>Log out</title>
+  <title>Log out or switch users</title>
 
-  <p>To let other users use your computer, you need to log out.</p>
+  <p>To let other users use your computer, you can either log out, or leave
+  yourself logged in and just switch users. If you switch users, all of
+  your applications will continue running, and everything will be where you
+  left it when you log back in.</p>
 
   <p>To <gui>Log Out</gui>, click the user menu on the right side of the taskbar,
   expand <gui>Power Off / Log Out</gui>, and select <gui>Log Out</gui>.</p>
 
-  <note if:test="!platform:gnome-classic !platform:endless">
+  <note if:test="!platform:gnome-classic">
     <p>The <gui>Log Out</gui> and <gui>Switch User</gui> entries only appear in
     the menu if you have more than one user account on your system.</p>
   </note>

--- a/gnome-help/C/shell-introduction.page
+++ b/gnome-help/C/shell-introduction.page
@@ -86,11 +86,7 @@
   <link xref="status-icons">system properties</link> like sound, networking,
   and power. In the system menu in the taskbar, you can change the volume or
   screen brightness, edit your <gui>Wi-Fi</gui> connection details, check your
-  battery status, and more.</p>
-
-  <p>If you have a screen that supports vertical or horizontal rotation, you can also
-  quickly rotate the screen from the system menu. If your screen does not support rotation,
-  you will not see the button.</p>
+  battery status, log out or switch users, and turn off your computer.</p>
 
 <links type="section"/>
 
@@ -279,11 +275,16 @@ messages will be presented, such as when your battery is critically low.</p>
 -->
 
   <p>When you leave your computer, you can lock your screen to prevent other
-  people from using it. You can also suspend or power off the computer from the menu.</p>
+  people from using it. You can also quickly switch users without logging out
+  completely to give somebody else access to the computer, or you can
+  suspend or power off the computer from the menu. If you have a screen 
+  that supports vertical or horizontal rotation, you can quickly rotate the 
+  screen from the system menu. If your screen does not support rotation,
+  you will not see the button.</p>
 
   <list style="compact">
     <item>
-      <p><link xref="shell-exit">Learn more about logging out, suspending and turning off your computer.</link></p>
+      <p><link xref="shell-exit">Learn more about switching users, logging out, and turning off your computer.</link></p>
     </item>
   </list>
 

--- a/gnome-help/C/shell-introduction.page
+++ b/gnome-help/C/shell-introduction.page
@@ -88,6 +88,10 @@
   screen brightness, edit your <gui>Wi-Fi</gui> connection details, check your
   battery status, log out or switch users, and turn off your computer.</p>
 
+  <p>If you have a screen that supports vertical or horizontal rotation, you can also
+  quickly rotate the screen from the system menu. If your screen does not support rotation,
+  you will not see the button.</p>
+
 <links type="section"/>
 
 <!-- TODO: Replace "Activities overview" title for classic mode with something
@@ -277,10 +281,7 @@ messages will be presented, such as when your battery is critically low.</p>
   <p>When you leave your computer, you can lock your screen to prevent other
   people from using it. You can also quickly switch users without logging out
   completely to give somebody else access to the computer, or you can
-  suspend or power off the computer from the menu. If you have a screen 
-  that supports vertical or horizontal rotation, you can quickly rotate the 
-  screen from the system menu. If your screen does not support rotation,
-  you will not see the button.</p>
+  suspend or power off the computer from the menu.</p>
 
   <list style="compact">
     <item>

--- a/gnome-help/C/shell-lockscreen.page
+++ b/gnome-help/C/shell-lockscreen.page
@@ -42,7 +42,9 @@
   <key>Esc</key> or <key>Enter</key>.
   This will reveal the login screen, where you can enter your password to
   unlock. Alternatively, just start typing your password and the login screen
-  will be automatically shown as you type.</p>
+  will be automatically shown as you type. You can also switch users at the
+  bottom right of the login screen if your system is configured for more than
+  one.</p>
 
   <p>To hide notifications from the lock screen, see
   <link xref="shell-notifications#lock-screen-notifications"/>.</p>

--- a/gnome-help/C/user-changepicture.page
+++ b/gnome-help/C/user-changepicture.page
@@ -33,7 +33,7 @@
 
   <title>Change your login screen photo</title>
 
-  <p>In the login screen, you will see a list of users with
+  <p>When you log in or switch users, you will see a list of users with
   their login photos. You can change your photo to a stock image or an
   image of your own.</p>
 


### PR DESCRIPTION
The whole commit history on top of upstream really could use some love/cleanup but not covered here (-> separate task).

https://phabricator.endlessm.com/T31491