### PR TITLE
fixup! endless: Rename ‘Activities overview’ to ‘Desktop’

### DIFF
--- a/gnome-help/C/net-default-browser.page
+++ b/gnome-help/C/net-default-browser.page
@@ -39,7 +39,7 @@
   <steps>
     <item>
       <p>Go to the Desktop and
-      start typing <gui>Default Applications</gui>.</p>
+      start typing <input>Default Applications</input>.</p>
     </item>
     <item>
       <p>Click on <gui>Default Applications</gui> to open the panel.</p>


### PR DESCRIPTION
The markup should not have been changed as part of this semi-mechanical
replacement of terminology.

This commit can be squashed into the original one next time we rebase.

Spotted by Will in https://phabricator.endlessm.com/T32665#914145

https://phabricator.endlessm.com/T32665