### PR TITLE
gnome-help/Makefile.am: Add missing figures

### DIFF
--- a/gnome-help/Makefile.am
+++ b/gnome-help/Makefile.am
@@ -84,6 +84,8 @@ HELP_MEDIA = \
 	figures/network-wireless-disabled-symbolic.svg \
 	figures/preferences-desktop-accessibility-symbolic.svg \
 	figures/printing-select.png \
+	figures/ps-button.svg \
+	figures/ps-create.svg \
 	figures/rotation-allowed-symbolic.svg \
 	figures/rotation-locked-symbolic.svg \
 	figures/screenshot-tool.png \


### PR DESCRIPTION
The Makefile for gnome-help was missing some figures, resulting in an error when we try to build pages for the online user documentation. This had been fixed upstream, but the fix was only in gnome-user-docs 44+: https://gitlab.gnome.org/GNOME/gnome-user-docs/-/merge_requests/164.

https://phabricator.endlessm.com/T35213